### PR TITLE
Optimize the code to make it more convenient to use.

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -3,10 +3,10 @@ export {}
 import {ccc, ClientPublicTestnet, hashTypeId, Script, Signer, SignerCkbPrivateKey, Transaction} from "@ckb-ccc/core"
 import { createSpore, findSpore, getSporeScriptInfo, getSporeScriptInfos, transferSpore } from "@ckb-ccc/spore";
 import * as dotenv from 'dotenv';
+import { COMPOSE_CELL_DEPS, SHADOWLOCK_CODEHASH } from "./config";
 dotenv.config();
 
-async function main() {
-
+async function composeNervape(nervapeSporeID: string, bundleGearSporeID: string) {
     const rpcURL = process.env.CKB_RPC_URL? process.env.CKB_RPC_URL:"https://testnet.ckbapp.dev/"
     console.log(`Using RPC: ${rpcURL}`);
     const client = new ClientPublicTestnet({
@@ -22,12 +22,11 @@ async function main() {
     console.log(`address:${address}`);
     const lock = address.script;
 
-    const delegateRef = await findSpore(client, "0x5e0ebfde2891968870b57e52aa8765c39a4f389f69dd575544c7154fd9ffb899"); // the fake nervape cell
+    const delegateRef = await findSpore(client, nervapeSporeID); // the nervape cell
     console.log(`delegate ref type hash:${delegateRef?.cell.cellOutput.type?.hash()}`);
     const shadowLockArgs = `0x07${delegateRef?.cell.cellOutput.type?.hash().slice(2)}`;
-    const codeHash = "0x6361d4b20d845953d9c9431bbba08905573005a71e2a2432e7e0e7c685666f24";
     const shadowLock =  ccc.Script.from({
-        codeHash,
+        codeHash: SHADOWLOCK_CODEHASH,
         args: shadowLockArgs,
         hashType: "data1",
     });
@@ -48,11 +47,11 @@ async function main() {
     console.log(`shadowLockHash: ${shadowLockHash}`);
     const delegateToShadowLockArgs = `0x00${shadowLockHash.slice(2)}`;
     const delegateToShadowLock = ccc.Script.from({
-        codeHash,
+        codeHash: SHADOWLOCK_CODEHASH,
         args: delegateToShadowLockArgs,
         hashType: "data1",
     });
-    const bundleGearSporeID = "0x3d18bb7ed80f10e2a5c98a8e44697a79091e54c081d478d3ae7863e021d527ff";
+
     const makeBundleTx = await transferSpore(
         {
             signer,
@@ -63,19 +62,23 @@ async function main() {
     );
 
     const { tx } = makeBundleTx;
-    await tx.addCellDeps({
-        outPoint: {
-          txHash: "0x2d8a311a55e42d7d6810610149f6e125f0d292112f8ed4a21177aec05da2b905",
-          index: 0x0,
-        },
-        depType: "code",
-      });
+    await tx.addCellDeps(COMPOSE_CELL_DEPS);
 
     await tx.completeFeeChangeToLock(signer, lock);
     const signedTx = await signer.signTransaction(tx);
     const txHash = await client.sendTransaction(signedTx);
     console.log(`txHash: ${txHash}, https://testnet.explorer.nervos.org/transaction/${txHash}`);
+}
 
+async function main() {
+    // The sporeID is the args field in the Type Script of the spore cell info.
+    await composeNervape(
+        "0x4ebc380ae48eadd747ee1a29fe555b6c9e7eba28da47027e1fc009dd5eca0807",
+        "0x087c963459a8207aa114d8c8ebc2a7afe3376c5f06ba9e224bbc3057f708e4ee"
+    );
+
+    // View the result tx here: 
+    // https://testnet.explorer.nervos.org/transaction/0x2e0c219502ddf04101d134af1bd2c1aba49d1669c464ce11adce916195c02792
 }
 
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+export const SHADOWLOCK_CODEHASH = "0x6361d4b20d845953d9c9431bbba08905573005a71e2a2432e7e0e7c685666f24";
+
+export const COMPOSE_CELL_DEPS = {
+    outPoint: {
+        txHash: "0x2d8a311a55e42d7d6810610149f6e125f0d292112f8ed4a21177aec05da2b905",
+        index: 0x0,
+    },
+    depType: "code",
+}

--- a/src/decompose.ts
+++ b/src/decompose.ts
@@ -3,10 +3,10 @@ export {}
 import {ccc, ClientPublicTestnet, hashTypeId, Script, Signer, SignerCkbPrivateKey, Transaction} from "@ckb-ccc/core"
 import { findSpore, meltSpore, transferSpore } from "@ckb-ccc/spore";
 import * as dotenv from 'dotenv';
+import { COMPOSE_CELL_DEPS } from "./config";
 dotenv.config();
 
-
-async function main() {
+async function decomposeNervape(shadowCellSporeID: string, nervapeSporeID: string, bundleGearSporeID: string) {
     const rpcURL = process.env.CKB_RPC_URL? process.env.CKB_RPC_URL:"https://testnet.ckbapp.dev/"
     console.log(`Using RPC: ${rpcURL}`);
     const client = new ClientPublicTestnet({
@@ -22,10 +22,6 @@ async function main() {
     console.log(`address:${address}`);
     const lock = address.script;
 
-
-    const shadowCellSporeID = "0xb1fc3693cc03734b2966276fdc8d834de5821e6ef86896d65396450f447caea0";
-    const codeHash = "0x6361d4b20d845953d9c9431bbba08905573005a71e2a2432e7e0e7c685666f24";
-
     // step1, destroy shadow cell
     const destroyShadowCellTx = await meltSpore({
         signer,
@@ -35,8 +31,6 @@ async function main() {
 
     // step 2, inject transfer gear
     // we call it decompose
-    const bundleGearSporeID = "0x3d18bb7ed80f10e2a5c98a8e44697a79091e54c081d478d3ae7863e021d527ff";
-
     const transferSporeTx = await transferSpore({
         signer,
         id: bundleGearSporeID,
@@ -44,23 +38,16 @@ async function main() {
         tx: destroyShadowCellTx.tx
     });
 
-    // make sure we input the proper nervape cell(fake)
-    
+    // make sure we input the proper nervape cell
     const injectDelegateRefTx = await transferSpore({
         signer,
-        id: "0x5e0ebfde2891968870b57e52aa8765c39a4f389f69dd575544c7154fd9ffb899",
+        id: nervapeSporeID,
         to: lock,
         tx: transferSporeTx.tx
     });
 
     const { tx } = injectDelegateRefTx;
-    await tx.addCellDeps({
-        outPoint: {
-            txHash: "0x2d8a311a55e42d7d6810610149f6e125f0d292112f8ed4a21177aec05da2b905",
-            index: 0x0,
-        },
-        depType: "code",
-    });
+    await tx.addCellDeps(COMPOSE_CELL_DEPS);
 
     await tx.completeFeeChangeToLock(signer, lock);
 
@@ -69,7 +56,18 @@ async function main() {
     const signedTx = await signer.signTransaction(tx);
     const txHash = await client.sendTransaction(signedTx);
     console.log(`txHash: ${txHash}, https://testnet.explorer.nervos.org/transaction/${txHash}`);
+}
 
+async function main() {
+    // The sporeID is the args field in the Type Script of the spore cell info.
+    await decomposeNervape(
+        "0x1ba8978da6bf76c326f994b50f97fc7372c020970f9a00f94076285f9bd2a335",
+        "0x4ebc380ae48eadd747ee1a29fe555b6c9e7eba28da47027e1fc009dd5eca0807",
+        "0x087c963459a8207aa114d8c8ebc2a7afe3376c5f06ba9e224bbc3057f708e4ee"
+    )
+
+    // View the result tx here: 
+    // https://testnet.explorer.nervos.org/transaction/0xc645f95710d4b641bcc30b05404378da2dd13a41b435789361a0eb1375e9d8d0
 }
 
 


### PR DESCRIPTION
Developers only need to pass in nervepeSporeID and gearSporeID to perform the compose operation. For decompose, just pass an additional shadowSporeID.